### PR TITLE
plotRowTree layout bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: miaViz
 Title: Microbiome Analysis Plotting and Visualization
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: 
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/plotTree.R
+++ b/R/plotTree.R
@@ -1012,7 +1012,8 @@ NODE_VARIABLES <- c("node_colour_by", "node_shape_by", "node_size_by")
                                  edge_size_by,
                                  line_alpha,
                                  line_width,
-                                 line_width_range)
+                                 line_width_range,
+                                 layout)
     # add tip and node points
     plot_out <- .plot_tree_node_points(plot_out,
                                        show_tips,
@@ -1240,12 +1241,14 @@ NODE_VARIABLES <- c("node_colour_by", "node_shape_by", "node_size_by")
                              edge_size_by,
                              line_alpha,
                              line_width,
-                             line_width_range){
+                             line_width_range,
+                             layout){
     # assemble arg list
     edge_out <- .get_edge_args(edge_colour_by,
                                edge_size_by,
                                alpha = line_alpha,
-                               size = line_width)
+                               size = line_width,
+                               layout = layout)
     plot_out <- plot_out +
         do.call(geom_tree, edge_out$args) + 
         theme_tree()

--- a/R/utils_plotting.R
+++ b/R/utils_plotting.R
@@ -332,7 +332,8 @@ NULL
     return(list(args = geom_args))
 }
 
-.get_edge_args <- function(edge_colour_by, edge_size_by, alpha = 1, size = NULL){
+.get_edge_args <- function(edge_colour_by, edge_size_by, alpha = 1, size = NULL,
+                           layout = NULL){
     aes_args <- list()
     if (!is.null(edge_colour_by)) {
         aes_args$colour <- "edge_colour_by"
@@ -347,6 +348,9 @@ NULL
     }
     if (is.null(edge_size_by)) {
         geom_args$size <- size
+    }
+    if (!is.null(layout)) {
+        geom_args$layout <- layout
     }
     return(list(args = geom_args))
 }


### PR DESCRIPTION
Hi,

here is bugfix for `plotRowTree`. 

Problem: `layout` was not passed all the way to the function that takes care of the edge coloring; `.plot_tree_edges`. Because of that the function used default layout to plot those edges --> colored, rectangular tree was plotted on top of another tree with intended layout. 

Solution: `layout` is passed to the `.plot_tree_edges`. `layout` is added as one of the arguments with `.get_edge_args `function. 

Issue: https://github.com/microbiome/miaViz/issues/23

-Tuomas