### PR TITLE
PlotAbundance bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: miaViz
 Title: Microbiome Analysis Plotting and Visualization
-Version: 1.1.2
+Version: 1.1.3
 Authors@R: 
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/plotAbundance.R
+++ b/R/plotAbundance.R
@@ -202,16 +202,14 @@ setMethod("plotAbundance", signature = c("SummarizedExperiment"),
         }
         # Checks if the list is a ggplot object or regular list of ggplot objects
         if( !is.ggplot(plot_out) ){
-            # If it contains only one ggplot object, only the object is returned
-            if ( length(plot_out) == 1) {
-                plot_out <- plot_out[["abundance"]]
-            }
-            # If the list contains multiple ggplot objects, only abundance and features
-            # plots are returned.
-            else{
+            # If features is specified, then only abundance and features plots are 
+            # returned as a list. If it is not, then only abundance plot is returned.
+            if( !is.null(features) ){
                 plot_out <- list(abundance = plot_out[["abundance"]], plot_out[[features]])
                 # Assigns the names back
                 names(plot_out) <- c("abundance", features)
+            } else{
+                plot_out <- plot_out[["abundance"]]
             }
         }
         plot_out

--- a/R/plotAbundance.R
+++ b/R/plotAbundance.R
@@ -19,7 +19,8 @@
 #' @param abund_values a \code{character} value defining which assay data to
 #'   use. (default: \code{abund_values = "relabundance"})
 #'   
-#' @param features data \code{colData} to be plotted below the abundance plot.
+#' @param features a single \code{character} value defining a column from 
+#'   \code{colData} to be plotted below the abundance plot.
 #'   Continuous numeric values will be plotted as point, whereas factors and
 #'   character will be plotted as colour-code bar. (default: \code{features =
 #'   NULL})
@@ -165,6 +166,9 @@ setMethod("plotAbundance", signature = c("SummarizedExperiment"),
         order_rank_by <- match.arg(order_rank_by, c("name","abund","revabund"))
         .check_abund_plot_args(one_facet = one_facet,
                                ncol = ncol)
+        if( !is.null(features) ){
+            features <- match.arg(features, colnames(colData(x)))
+        }
         #
         abund_data <- .get_abundance_data(x, rank, abund_values, order_rank_by,
                                           use_relative)

--- a/R/plotAbundance.R
+++ b/R/plotAbundance.R
@@ -201,10 +201,19 @@ setMethod("plotAbundance", signature = c("SummarizedExperiment"),
                     facet_wrap(~colour_by, ncol = ncol, scales = scales)
             }
         }
-        # Checks if the list contains only one element. If it does, only the element
-        # is returned. Otherwise the list is returned. 
-        if ( length(plot_out) == 1) {
-            plot_out <- plot_out[[1]]
+        # Checks if the list is a ggplot object or regular list of ggplot objects
+        if( !is.ggplot(plot_out) ){
+            # If it contains only one ggplot object, only the object is returned
+            if ( length(plot_out) == 1) {
+                plot_out <- plot_out[["abundance"]]
+            } 
+            # If the list contains multiple ggplot objects, only abundance and features
+            # plots are returned. 
+            else{
+                plot_out <- list(abundance = plot_out[["abundance"]], plot_out[[features]])
+                # Assigns the names back
+                names(plot_out) <- c("abundance", features)
+            }
         }
         plot_out
     }

--- a/R/plotAbundance.R
+++ b/R/plotAbundance.R
@@ -31,8 +31,7 @@
 #'   
 #' @param order_sample_by A single character value from the chosen rank of abundance
 #'   data or from \code{colData} to select values to order the abundance
-#'   plot by. If the value is not part of \code{features}, it will be added.
-#'   (default: \code{order_sample_by = NULL})
+#'   plot by. (default: \code{order_sample_by = NULL})
 #'   
 #' @param decreasing TRUE or FALSE: If the \code{order_sample_by} is defined and the
 #'   values are numeric, should the values used to order in decreasing or
@@ -57,7 +56,7 @@
 #'   \code{\link{mia-plot-args}} for more details
 #'
 #' @return 
-#' a \code{\link[ggplot2:ggplot]{ggplot}} object or list of 
+#' a \code{\link[ggplot2:ggplot]{ggplot}} object or list of two 
 #' \code{\link[ggplot2:ggplot]{ggplot}} objects, if `features` are added to 
 #' the plot. 
 #'
@@ -206,9 +205,9 @@ setMethod("plotAbundance", signature = c("SummarizedExperiment"),
             # If it contains only one ggplot object, only the object is returned
             if ( length(plot_out) == 1) {
                 plot_out <- plot_out[["abundance"]]
-            } 
+            }
             # If the list contains multiple ggplot objects, only abundance and features
-            # plots are returned. 
+            # plots are returned.
             else{
                 plot_out <- list(abundance = plot_out[["abundance"]], plot_out[[features]])
                 # Assigns the names back
@@ -360,7 +359,16 @@ MELT_VALUES <- "Value"
         abund_data <- abund_data[order(abund_data$colour_by, abund_data$X),]
         if(!is.null(features_data)){
             o <- order(factor(rownames(features_data), lvl))
-            features_data <- features_data[o,]
+            # If features and order_sample_by are the same, there is only one column.
+            # One column is converted to vector which is why it is converted back
+            # to data frame which is expected in next steps.
+            if(ncol(features_data) == 1) {
+                colname <- colnames(features_data)
+                features_data <- as.data.frame(features_data[o,])
+                colnames(features_data) <- colname
+            } else{
+                features_data <- features_data[o,]
+            }
         }
     }
     list(abund_data = abund_data, features_data = features_data)

--- a/R/plotAbundance.R
+++ b/R/plotAbundance.R
@@ -77,10 +77,20 @@
 #' plotAbundance(se, abund_values="counts", rank = NULL,
 #'               features = head(rownames(se)))
 #'               
-#' ## A feature e.g. from colData can be used for ordering samples before plot
+#' ## A feature from colData or taxon from chosen rank can be used for ordering samples.
 #' plotAbundance(se, abund_values="counts", rank = "Phylum",
-#'               features = "SampleType",
-#'               order_sample_by = "SampleType")
+#'               order_sample_by = "Bacteroidetes")
+#' 
+#' ## Features from colData can be plotted together with abundance plot.                      
+#' # Returned object is a list that includes two plot; other visualizes abundance
+#' # other features. 
+#' plot <- plotAbundance(se, abund_values = "counts", rank = "Phylum",
+#'                       features = "SampleType")
+#' \dontrun{
+#' # These two plots can be combined with wrap_plots function from patchwork package
+#' library(patchwork)
+#' wrap_plots(plot, ncol = 1)
+#' }
 #'               
 #' ## Compositional barplot with top 5 taxa and samples sorted by "Bacteroidetes"
 #' 
@@ -151,7 +161,7 @@ setMethod("plotAbundance", signature = c("SummarizedExperiment"),
                 ylab(ylab)
             return(plot)
         }
-        # input checks
+        ############################# INPUT CHECK #############################
         if(!.is_non_empty_string(rank)){
             stop("'rank' must be an non empty single character value.",
                  call. = FALSE)
@@ -169,7 +179,7 @@ setMethod("plotAbundance", signature = c("SummarizedExperiment"),
         if( !is.null(features) ){
             features <- match.arg(features, colnames(colData(x)))
         }
-        #
+        ########################### INPUT CHECK END ###########################
         abund_data <- .get_abundance_data(x, rank, abund_values, order_rank_by,
                                           use_relative)
         order_sample_by <- .norm_order_sample_by(order_sample_by,

--- a/R/plotAbundance.R
+++ b/R/plotAbundance.R
@@ -181,6 +181,11 @@ setMethod("plotAbundance", signature = c("SummarizedExperiment"),
                     facet_wrap(~colour_by, ncol = ncol, scales = scales)
             }
         }
+        # Checks if the list contains only one element. If it does, only the element
+        # is returned. Otherwise the list is returned. 
+        if ( length(plot_out) == 1) {
+            plot_out <- plot_out[[1]]
+        }
         plot_out
     }
 )

--- a/man/plotAbundance.Rd
+++ b/man/plotAbundance.Rd
@@ -34,7 +34,8 @@ object.}
 \item{rank}{a single \code{character} value defining the taxonomic rank to
 use. Must be a value of \code{taxonomyRanks(x)}.}
 
-\item{features}{data \code{colData} to be plotted below the abundance plot.
+\item{features}{a single \code{character} value defining a column from
+\code{colData} to be plotted below the abundance plot.
 Continuous numeric values will be plotted as point, whereas factors and
 character will be plotted as colour-code bar. (default: \code{features =
   NULL})}
@@ -45,8 +46,7 @@ sort by abundance values or by a reverse order of abundance values (\dQuote{reva
 
 \item{order_sample_by}{A single character value from the chosen rank of abundance
 data or from \code{colData} to select values to order the abundance
-plot by. If the value is not part of \code{features}, it will be added.
-(default: \code{order_sample_by = NULL})}
+plot by. (default: \code{order_sample_by = NULL})}
 
 \item{decreasing}{TRUE or FALSE: If the \code{order_sample_by} is defined and the
 values are numeric, should the values used to order in decreasing or
@@ -71,7 +71,7 @@ passed onto \code{\link[ggplot2:facet_wrap]{facet_wrap}}.}
 use. (default: \code{abund_values = "relabundance"})}
 }
 \value{
-a \code{\link[ggplot2:ggplot]{ggplot}} object or list of
+a \code{\link[ggplot2:ggplot]{ggplot}} object or list of two
 \code{\link[ggplot2:ggplot]{ggplot}} objects, if \code{features} are added to
 the plot.
 }
@@ -100,10 +100,20 @@ plotAbundance(se, abund_values="counts", rank = "Phylum", add_legend = FALSE)
 plotAbundance(se, abund_values="counts", rank = NULL,
               features = head(rownames(se)))
               
-## A feature e.g. from colData can be used for ordering samples before plot
+## A feature from colData or taxon from chosen rank can be used for ordering samples.
 plotAbundance(se, abund_values="counts", rank = "Phylum",
-              features = "SampleType",
-              order_sample_by = "SampleType")
+              order_sample_by = "Bacteroidetes")
+
+## Features from colData can be plotted together with abundance plot.                      
+# Returned object is a list that includes two plot; other visualizes abundance
+# other features. 
+plot <- plotAbundance(se, abund_values = "counts", rank = "Phylum",
+                      features = "SampleType")
+\dontrun{
+# These two plots can be combined with wrap_plots function from patchwork package
+library(patchwork)
+wrap_plots(plot, ncol = 1)
+}
               
 ## Compositional barplot with top 5 taxa and samples sorted by "Bacteroidetes"
 


### PR DESCRIPTION
Hi,

here is the bugfix for `plotAbundance` function. 

**1. Return object**

Returned object was always a list of ggplot objects. It was not intuitive when list contained only one ggplot object. 
**--> when features is not specified, only abundance plot is plotted and it is returned as it is**

When order_sample_by was specified with features, 3 plots was returned; abundance, order_sample_by and features 
**--> when features is specified, 2 plots - abundance and features plots - are returned**

**2. features plot was not plotted when features and order_sample_by had same value**

When _features_ and `order_sample_by `had same value, `features` data frame had only one column and that is why it was converted into vector in `.order_abund_feature_data`. Because data frame is expected in next steps, `features` plot was not plotted. 
**--> vector is converted back to data frame**

**3. features did not have input check**
 **--> input check is added**

Issue: https://github.com/microbiome/miaViz/issues/18

-Tuomas