### PR TITLE
plotAbundanceDensity bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: miaViz
 Title: Microbiome Analysis Plotting and Visualization
-Version: 1.1.4
+Version: 1.1.5
 Authors@R: 
     c(person(given = "Felix G.M.", family = "Ernst", role = c("aut", "cre"),
              email = "felix.gm.ernst@outlook.com",

--- a/R/plotAbundanceDensity.R
+++ b/R/plotAbundanceDensity.R
@@ -209,7 +209,7 @@ setMethod("plotAbundanceDensity", signature = c(object = "SummarizedExperiment")
     # Gets the assay
     mat <- assay(object, abund_values)
     # Gets the most abundant taxa
-    top_taxa <- getTopTaxa(object, n)
+    top_taxa <- getTopTaxa(object, top = n, abund_values = abund_values)
     # Subsets abundance table  by taking taxa of highest abundance
     mat <- mat[top_taxa, , drop=FALSE]
     # melt the data


### PR DESCRIPTION
Hi,

@ChouaibB reported following error

```
tse <- microbiomeDataSets::atlas1006()
tse <- transformSamples(tse, method = "relabundance")
# no error
plotAbundanceDensity(tse, layout = "density", abund_values = "relabundance", n = 10 ) + scale_x_log10()
# error
assay(tse,"counts") <- NULL
plotAbundanceDensity(tse, layout = "density", abund_values = "relabundance", n = 10 ) + scale_x_log10()
Error in assay(x, abund_values) : 
  'assay(<TreeSummarizedExperiment>, i="character", ...)' invalid subscript 'i'
'counts' not in names(assays(<TreeSummarizedExperiment>))
```
The problem was that `getTopTaxa` did expect `"counts"` because it was the default value of `abund_values` but it was not present in `SE`

-Tuomas