### PR TITLE
Checks fail, fix it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,5 +56,5 @@ Suggests:
     patchwork,
     microbiomeDataSets
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 VignetteBuilder: knitr

--- a/tests/testthat/test-2plotTree.R
+++ b/tests/testthat/test-2plotTree.R
@@ -58,7 +58,7 @@ test_that("plot tree", {
     library(scater)
     library(mia)
     data(GlobalPatterns)
-    altExp(GlobalPatterns,"genus") <- agglomerateByRank(GlobalPatterns,"Genus")
+    altExp(GlobalPatterns,"genus") <- agglomerateByRank(GlobalPatterns,"Genus", make_unique = FALSE)
     altExp(GlobalPatterns,"genus") <- addPerFeatureQC(altExp(GlobalPatterns,"genus"))
     rowData(altExp(GlobalPatterns,"genus"))$log_mean <- log(rowData(altExp(GlobalPatterns,"genus"))$mean)
     top_taxa <- getTopTaxa(altExp(GlobalPatterns,"genus"),


### PR DESCRIPTION
This fixes the checks

https://bioconductor.org/checkResults/devel/bioc-LATEST/miaViz/nebbiolo2-checksrc.html

By default, after agglomeration it was possible that there were duplicated rownames. --> duplicated rownames caused a warning in plotRowTree --> since now agglomerateByRank returns unique [rownames](https://github.com/microbiome/mia/commit/f49ea28eb040e0e635a0fc46dbca23fdfbbd7ab4), there was no warning --> checks were still expecting warning --> checks fail 

To fix the checks, I modified them so that ununique rownames are returned after agglomerating step (make_unique = FALSE)

(master branch's checks are ok, because mia had the commit just a short time ago)
