### PR TITLE
Ord trajec

### DIFF
--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -378,13 +378,25 @@ p1 +
 Examples of 30 days trajectories:
 
 ```{r}
-# making info of samples corresponding to IDs having measurements up till 30 days
-IDs_keep <- sapply(colData(tse)$ID_Number %>% unique, function(id_n) {
-    if(seq(30) %in%
-       colData(tse)[colData(tse)$ID_Number==id_n, "Day_Number"] %>%
-       all) id_n
-})
-colData(tse)$has_30d <- 
+DF <- data.frame(reducedDim(tse) %>% `colnames<-`(c("PCoA1","PCoA2")),
+                 colData(tse)[,c("Day_Number","ID_Number")]) %>%
+    filter(Day_Number %in% seq(30)) %>%
+    tidyr::pivot_wider(id_cols = ID_Number, names_from = Day_Number,
+                       values_from = c(PCoA1,PCoA2))
+df <- DF %>% select(c(ID_Number,PCoA1_1, PCoA2_1, PCoA1_2, PCoA2_2)) %>% 
+    `colnames<-`(c("ID_Number","x_start","y_start", "x_end", "y_end"))
+for (i in 2:29) {
+    df <- rbind(df,
+                DF %>% select(c("ID_Number",
+                                paste0(c("PCoA1_","PCoA2_"),i),
+                                paste0(c("PCoA1_","PCoA2_"),i+1))) %>% 
+    `colnames<-`(c("ID_Number","x_start","y_start", "x_end", "y_end")))
+}
+
+p1 + 
+    geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
+                     color=ID_Number), data = df %>% filter(ID_Number %in% c(800,802)), 
+                 arrow = arrow(length = unit(0.1,"cm")))
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -328,21 +328,11 @@ plotDMNFit(dmn_se, type = "laplace")
 
 # Ordination of serial data and trajectories
 
+
 ```{r}
 library(dplyr)
-data(temporalMicrobiome20, package = "miaTime")
-## Pre-processing data
-# removing NAs
-tse <- temporalMicrobiome20[,colData(temporalMicrobiome20)$Day_Number!="NA"]
-# making Day_Number as factor
-colData(tse)$Day_Number <- colData(tse)$Day_Number %>% as.integer() %>%
-    as.factor()
-## transforming data
-# imputing missing values with 0
-assay(tse,"counts")[is.na(assay(tse,"counts"))] <- 0 # is ok?
-# relative abundance transform
-tse <- transformCounts(tse, abund_values = "counts", method = "relabundance",
-                       pseudocount = 1)
+tse <- hitchip1006
+tse <- transformCounts(tse, method = "relabundance")
 ## Ordination with PCoA with Bray-Curtis dissimilarity
 tse <- runMDS(tse, FUN = vegan::vegdist, method = "bray",
                   name = "PCoA_BC", exprs_values = "relabundance",
@@ -359,20 +349,49 @@ p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
 p1
 ```
 
-With two points; day 1 and day 30:
+Retrieving information about available trajectories:
 
 ```{r}
-df <- data.frame(reducedDim(tse) %>% `colnames<-`(c("PCoA1","PCoA2")),
-                 colData(tse)[,c("Day_Number","ID_Number")]) %>%
-    filter(Day_Number %in% c(1,30)) %>%
-    tidyr::pivot_wider(id_cols = ID_Number, names_from = Day_Number,
+colData(tse)$time <- as.factor(colData(tse)$time)
+# trajectories info
+traj_info <- table(colData(tse)$subject,colData(tse)$time)
+# has at least two point
+traj_info <- traj_info[rowSums(traj_info)!=1,]
+table(rowSums(traj_info)) %>% as.data.frame() %>%
+    `colnames<-`(c("Trajectories Lengths", "Counts"))
+```
+
+Lets look at trajectories with two time points:
+
+```{r}
+# subject with 2 points trajectory
+ids_2tp <- which(rowSums(traj_info)==2) %>% names()
+
+df <- data.frame(
+    reducedDim(tse[,colData(tse)$subject %in% ids_2tp],"PCoA_BC") %>%
+        `colnames<-`(c("PCoA1","PCoA2")),
+    colData(tse[,colData(tse)$subject %in% ids_2tp])[,c("time","subject")]) %>%
+    arrange(subject) %>% mutate(time_mod=rep(c("tp_1","tp_2"), nrow(.)/2)) %>% 
+    tidyr::pivot_wider(id_cols = subject, names_from = time_mod,
                        values_from = c(PCoA1,PCoA2)) %>% 
-    mutate(change=sqrt((PCoA1_30-PCoA1_1)^2+(PCoA2_30-PCoA2_1)^2))
+    `colnames<-`(c("subject","x_start", "x_end", "y_start", "y_end")) %>% 
+    mutate(change=sqrt((.[[3]]-.[[2]])^2+(.[[5]]-.[[4]])^2))
 
 p1 + 
-    geom_segment(aes(x=PCoA1_1, y=PCoA2_1, xend=PCoA1_30, yend=PCoA2_30,
+    geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
                      color=change), data = df, 
-                 arrow = arrow(length = unit(0.1,"cm")))
+                 arrow = arrow(length = unit(0.1,"cm")))+
+    labs(title = "All two time point trajectories")
+```
+
+top 10 % trajectories (in terms of change) with two time points:
+
+```{r}
+p1 + 
+    geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
+                     color=change), data = df %>% top_frac(0.1, change), 
+                 arrow = arrow(length = unit(0.1,"cm")))+
+    labs(title = "top 10% trajectories from time point 1 to 2")
 ```
 
 Examples of 30 days trajectories:
@@ -395,8 +414,8 @@ for (i in 2:29) {
 
 p1 + 
     geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
-                     color=ID_Number), data = df %>% filter(ID_Number %in% c(800,802)), 
-                 arrow = arrow(length = unit(0.1,"cm")))
+                     color=ID_Number), data = df %>% filter(ID_Number==801), 
+                 arrow = arrow(length = unit(0.2,"cm")))
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -355,7 +355,7 @@ Retrieving information about available trajectories:
 colData(tse)$time <- as.factor(colData(tse)$time)
 # trajectories info
 traj_info <- table(colData(tse)$subject,colData(tse)$time)
-# has at least two point
+# has at least two points
 traj_info <- traj_info[rowSums(traj_info)!=1,]
 table(rowSums(traj_info)) %>% as.data.frame() %>%
     `colnames<-`(c("Trajectories Lengths", "Counts"))
@@ -394,28 +394,42 @@ p1 +
     labs(title = "top 10% trajectories from time point 1 to 2")
 ```
 
-Examples of 30 days trajectories:
+Trajectories with multiple points (e.g. 5 poins which was maximum):
 
 ```{r}
-DF <- data.frame(reducedDim(tse) %>% `colnames<-`(c("PCoA1","PCoA2")),
-                 colData(tse)[,c("Day_Number","ID_Number")]) %>%
-    filter(Day_Number %in% seq(30)) %>%
-    tidyr::pivot_wider(id_cols = ID_Number, names_from = Day_Number,
+# subject with maximum points in a trajectory
+max_tp <- max(rowSums(traj_info))
+ids_max_tp <- which(rowSums(traj_info)==max_tp) %>% names()
+
+DF <- data.frame(
+    reducedDim(tse[,colData(tse)$subject %in% ids_max_tp],"PCoA_BC") %>%
+        `colnames<-`(c("PCoA1","PCoA2")),
+    colData(tse[,colData(tse)$subject %in% ids_max_tp])[,c("time","subject")]) %>%
+    arrange(subject) %>% mutate(time_mod=rep(paste0("tp_", seq(max_tp)), nrow(.)/max_tp)) %>% 
+    tidyr::pivot_wider(id_cols = subject, names_from = time_mod,
                        values_from = c(PCoA1,PCoA2))
-df <- DF %>% select(c(ID_Number,PCoA1_1, PCoA2_1, PCoA1_2, PCoA2_2)) %>% 
-    `colnames<-`(c("ID_Number","x_start","y_start", "x_end", "y_end"))
-for (i in 2:29) {
+df <- DF %>% select(c(subject,PCoA1_tp_1, PCoA2_tp_1, PCoA1_tp_2, PCoA2_tp_2)) %>% 
+    `colnames<-`(c("subject","x_start","y_start", "x_end", "y_end"))
+for (i in 2:(max_tp-1)) {
     df <- rbind(df,
-                DF %>% select(c("ID_Number",
-                                paste0(c("PCoA1_","PCoA2_"),i),
-                                paste0(c("PCoA1_","PCoA2_"),i+1))) %>% 
-    `colnames<-`(c("ID_Number","x_start","y_start", "x_end", "y_end")))
+                DF %>% select(c("subject",
+                                paste0(c("PCoA1_tp_","PCoA2_tp_"),i),
+                                paste0(c("PCoA1_tp_","PCoA2_tp_"),i+1))) %>% 
+    `colnames<-`(c("subject","x_start","y_start", "x_end", "y_end")))
 }
+
+df_start_end <- rbind(
+    DF[,grep("tp_1", colnames(DF))] %>% `colnames<-`(c("PCoA1","PCoA2")) %>%
+        mutate(tp=rep("start", nrow(.))),
+    DF[,grep(paste0("tp_",max_tp), colnames(DF))] %>%
+        `colnames<-`(c("PCoA1","PCoA2")) %>% mutate(tp=rep("end", nrow(.))))
 
 p1 + 
     geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
-                     color=ID_Number), data = df %>% filter(ID_Number==801), 
-                 arrow = arrow(length = unit(0.2,"cm")))
+                     color=subject), data = df)+
+    geom_point(aes(x=PCoA1,y=PCoA2, shape=tp),data = df_start_end, size=2)+
+    scale_shape_manual(name="",values = c("start"=8, "end"=5))+
+    labs(title = "Multiple points trajectories")
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -347,7 +347,6 @@ tse <- runMDS(tse, FUN = vegan::vegdist, method = "bray", name = "PCoA_BC",
               exprs_values = "relabundance", na.rm = TRUE)
 # plot
 p <- plotReducedDim(tse, dimred = "PCoA_BC")
-
 p
 ```
 
@@ -369,6 +368,7 @@ Lets look at all trajectories having two time points in the data:
 p + geom_path(aes(x=X1, y=X2, group=subject), 
               arrow=arrow(length = unit(0.1, "inches")),
               # combining ordination data and metadata then selecting the subjects
+              # Note, scuttle::makePerCellDF could also be used for the purpose.
               data = subset(data.frame(reducedDim(tse), colData(tse)),
                             subject %in% selected.subjects) %>% arrange(time))+
     labs(title = "All trajectories with two time points")+
@@ -388,19 +388,25 @@ top.selected.subjects <- subset(data.frame(reducedDim(tse), colData(tse)),
 # plot
 p + geom_path(aes(x=X1, y=X2,
                   color=time_divergence, group=subject),
+              # the data is sorted in descending order in terms of time
+              # since geom_path will use the first occurring observation
+              # to color the corresponding segment. Without the sorting
+              # geom_path will pick up NA values (corresponding to initial time
+              # points); breaking the example.
               data = subset(data.frame(reducedDim(tse), colData(tse)),
                             subject %in% top.selected.subjects) %>% 
-                  arrange(desc(time)), 
+                  arrange(desc(time)),
+              # arrow end is reversed, due to the earlier sorting.
               arrow=arrow(length = unit(0.1, "inches"), ends = "first"))+
     labs(title = "Top 10%  divergent trajectories from time point one to two")+
     scale_color_gradient2(low="white", high="red")+
     theme(plot.title = element_text(hjust = 0.5))
 ```
 
-Plotting an example of the trajectory with the highest total divergence:
+Plotting an example of the trajectory with the maximum total divergence:
 
 ```{r}
-# Get first subject to have maximum time points
+# Get subject with the maximum total divergence
 selected.subject <- data.frame(reducedDim(tse), colData(tse)) %>%
     group_by(subject) %>% 
     summarise(total_divergence = sum(time_divergence, na.rm = TRUE)) %>%

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -326,8 +326,10 @@ names(metadata(dmn_se))
 plotDMNFit(dmn_se, type = "laplace")
 ```
 
-# Ordination of serial data and trajectories
+# Serial data ordination and trajectories
 
+Principal Coordinate Analysis using Bray-Curtis dissimilarity on the
+`hitchip1006` dataset:
 
 ```{r}
 library(dplyr)
@@ -362,7 +364,7 @@ table(rowSums(traj_info)) %>% as.data.frame() %>%
     `colnames<-`(c("Trajectories Lengths", "Counts"))
 ```
 
-Lets look at all present trajectories in th data:
+Lets look at all present trajectories in the data:
 
 ```{r}
 # keeping only data that has one-to-one link from one point to another
@@ -387,15 +389,15 @@ df_start_end <- rbind(
 # plot
 p1 + 
     geom_path(aes(x=PC1, y=PC2, color=subject),
-              data = df )+ # %>% filter(subject %in% ids_max_tp)
+              data = df )+ 
     geom_point(aes(x=PC1,y=PC2, shape=tp),
-               data = df_start_end , # %>% filter(subject %in% ids_max_tp)
+               data = df_start_end ,
                size=2)+
     scale_shape_manual(name="",values = c("start"=8, "end"=5))+
     labs(title = "All present trajectories")
 ```
 
-Filtering by trajectory length:
+Filtering by trajectory length and displaying top 10%:
 
 ```{r}
 # calculating trajectory lengths and merge
@@ -406,7 +408,7 @@ df <- merge(df,
                }))
 # plot
 p1 + 
-    geom_path(aes(x=PC1, y=PC2, color=subject),
+    geom_path(aes(x=PC1, y=PC2, color=change, group=subject),
               data = df %>% top_frac(0.1, change))+
     geom_point(aes(x=PC1,y=PC2, shape=tp),
                data = df_start_end %>% 
@@ -415,7 +417,27 @@ p1 +
                                    select(subject) %>% .[[1]] %>% unique())), 
                size=2)+
     scale_shape_manual(name="",values = c("start"=8, "end"=5))+
-    labs(title = "Top 10% longest trajectories")
+    labs(title = "Top 10% longest trajectories")+
+    scale_color_gradient2(low="white", high="red")
+```
+
+Filtering by trajectory length and displaying top 10% along with BMI grouping:
+
+```{r}
+# adding BMI grouping info
+df$bmi_group <- colData(tse)[df$sample_id, "bmi_group"]
+# plot
+p1 + 
+    geom_path(aes(x=PC1, y=PC2, color=bmi_group, group=subject),
+              data = df %>% top_frac(0.1, change))+
+    geom_point(aes(x=PC1,y=PC2, shape=tp),
+               data = df_start_end %>% 
+                   filter(subject %in%
+                              (df %>% top_frac(0.1, change) %>%
+                                   select(subject) %>% .[[1]] %>% unique())), 
+               size=2)+
+    scale_shape_manual(name="",values = c("start"=8, "end"=5))+
+    labs(title = "Top 10% longest trajectories and BMI grouping")
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -449,6 +449,36 @@ p1 +
 ```
 
 
+```{r}
+df <- traj_info %>% reshape2::melt() %>% `colnames<-`(c("subject", "time", "value")) %>%
+    filter(value>0) %>% arrange(subject, time) %>% 
+    mutate(sample_id = apply(., 1, function(row) {
+        colData(tse[,colData(tse)$subject == row[1] & colData(tse)$time == row[2]])$sample
+        }))
+    
+df$subject <- as.factor(df$subject)
+df <- cbind(df, 
+      reducedDim(
+          tse[,(colData(tse)$subject %in% df$subject &
+                    colData(tse)$time %in% df$time)], "PCoA_BC") %>%
+          `colnames<-`(c("PC1","PC2")))
+# df_start_end <- df %>% group_by(subject) %>% summarise(start=min(time), end=max(time)) %>%
+#     tidyr::pivot_longer(cols = c(start, end), names_to = "side", values_to = "time") %>% 
+#     mutate(sample_id = apply(., 1, function(row) {
+#         colData(tse[,colData(tse)$subject == row[1] & colData(tse)$time == row[3]])$sample
+#         }))
+# df_start_end <- cbind(
+#     df_start_end,
+#     reducedDim(
+#           tse[,(colData(tse)$subject %in% df_start_end$subject &
+#                     colData(tse)$time %in% df_start_end$time)], "PCoA_BC") %>%
+#           `colnames<-`(c("PC1","PC2")))
+
+p1 + 
+    geom_line(aes(x=PC1, y=PC2, color=subject), data = df)
+```
+
+
 More examples and materials are available at Orchestrating Microbiome Analysis [@OMA].
 
 # Session info

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -331,6 +331,7 @@ plotDMNFit(dmn_se, type = "laplace")
 
 ```{r}
 library(dplyr)
+data(hitchip1006, package = "miaTime")
 tse <- hitchip1006
 tse <- transformCounts(tse, method = "relabundance")
 ## Ordination with PCoA with Bray-Curtis dissimilarity
@@ -392,6 +393,21 @@ p1 +
                      color=change), data = df %>% top_frac(0.1, change), 
                  arrow = arrow(length = unit(0.1,"cm")))+
     labs(title = "top 10% trajectories from time point 1 to 2")
+```
+
+Coloring trajectories with metadata (e.g. nationality): 
+
+```{r}
+df <- df %>%
+    mutate(colData(tse) %>% as_tibble()  %>%
+    filter(subject %in% df$subject) %>% select(subject, nationality) %>%
+    distinct() %>% select(nationality))
+
+p1 + 
+    geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
+                     color=nationality), data = df, 
+                 arrow = arrow(length = unit(0.1,"cm")))+
+    labs(title = "Trajectories coloured with nationality ")
 ```
 
 Trajectories with multiple points (e.g. 5 poins which was maximum):

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -343,19 +343,12 @@ data(hitchip1006, package = "miaTime")
 tse <- hitchip1006
 tse <- transformCounts(tse, method = "relabundance")
 ## Ordination with PCoA with Bray-Curtis dissimilarity
-tse <- runMDS(tse, FUN = vegan::vegdist, method = "bray",
-                  name = "PCoA_BC", exprs_values = "relabundance",
-              na.rm = TRUE)
-# Calculating Explained variance
-e <- attr(reducedDim(tse, "PCoA_BC"), "eig")
-rel_eig <- e/sum(e[e>0])
+tse <- runMDS(tse, FUN = vegan::vegdist, method = "bray", name = "PCoA_BC",
+              exprs_values = "relabundance", na.rm = TRUE)
 # plot
 p <- plotReducedDim(tse, dimred = "PCoA_BC")
 
-p + labs(x = paste("PCoA 1 (", round(100 * rel_eig[[1]],1), "%", ")", sep = ""),
-         y = paste("PCoA 2 (", round(100 * rel_eig[[2]],1), "%", ")", sep = ""),
-         title="PCoA - Bray-Curtis")+
-    theme(plot.title = element_text(hjust = 0.5))
+p
 ```
 
 Retrieving information about all available trajectories:
@@ -372,12 +365,12 @@ table(table(tse$subject)) %>% as.data.frame() %>%
 Lets look at all trajectories having two time points in the data:
 
 ```{r}
-# adding metadata for the plot
-p$data <- cbind(p$data, colData(tse))
 # plot
-p + geom_path(aes(x=X, y=Y, group=subject), 
+p + geom_path(aes(x=X1, y=X2, group=subject), 
               arrow=arrow(length = unit(0.1, "inches")),
-              data = subset(p$data, subject %in% selected.subjects))+
+              # combining ordination data and metadata then selecting the subjects
+              data = subset(data.frame(reducedDim(tse), colData(tse)),
+                            subject %in% selected.subjects) %>% arrange(time))+
     labs(title = "All trajectories with two time points")+
     theme(plot.title = element_text(hjust = 0.5))
 ```
@@ -388,15 +381,15 @@ Filtering the two time point trajectories by divergence and displaying top 10%:
 library(miaTime)
 # calculating step wise divergence based on the microbial profiles
 tse <- getStepwiseDivergence(tse, group = "subject", time_field = "time")
-# adding metadata for the plot
-p$data <- cbind(p$data, colData(tse)[,"time_divergence", drop=FALSE])
 # retrieving the top 10% divergent subjects having two time points
-top.selected.subjects <- p$data %>% filter(subject %in% selected.subjects) %>%
+top.selected.subjects <- subset(data.frame(reducedDim(tse), colData(tse)),
+                            subject %in% selected.subjects) %>% 
     top_frac(0.1, time_divergence) %>% select(subject) %>% .[[1]]
 # plot
-p + geom_path(aes(x=X, y=Y,
+p + geom_path(aes(x=X1, y=X2,
                   color=time_divergence, group=subject),
-              data = subset(p$data, subject %in% top.selected.subjects) %>% 
+              data = subset(data.frame(reducedDim(tse), colData(tse)),
+                            subject %in% top.selected.subjects) %>% 
                   arrange(desc(time)), 
               arrow=arrow(length = unit(0.1, "inches"), ends = "first"))+
     labs(title = "Top 10%  divergent trajectories from time point one to two")+
@@ -408,12 +401,14 @@ Plotting an example of the trajectory with the highest total divergence:
 
 ```{r}
 # Get first subject to have maximum time points
-selected.subject <- p$data %>% group_by(subject) %>%
-    summarise(total_divergence=sum(time_divergence, na.rm = TRUE)) %>%
+selected.subject <- data.frame(reducedDim(tse), colData(tse)) %>%
+    group_by(subject) %>% 
+    summarise(total_divergence = sum(time_divergence, na.rm = TRUE)) %>%
     filter(total_divergence==max(total_divergence)) %>% select(subject) %>% .[[1]]
 # plot
-p +  geom_path(aes(x=X, y=Y, group=subject),
-              data = subset(p$data, subject %in% selected.subject),
+p +  geom_path(aes(x=X1, y=X2, group=subject),
+              data = subset(data.frame(reducedDim(tse), colData(tse)),
+                            subject %in% selected.subject) %>% arrange(time),
               arrow=arrow(length = unit(0.1, "inches")))+
     labs(title = "Longest trajectory by divergence")+
     theme(plot.title = element_text(hjust = 0.5))

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -55,7 +55,7 @@ behaves as `plotExpression`.
 
 ```{r}
 plotAbundance(GlobalPatterns, rank = NULL, 
-              features = "549322", abund_values = "counts")
+              features = "549322", assay_name = "counts")
 ```
 
 However, if the `rank` is set not `NULL` a bar plot is returned. At the same
@@ -66,7 +66,7 @@ GlobalPatterns <- transformCounts(GlobalPatterns, method = "relabundance")
 ```
 
 ```{r}
-plotAbundance(GlobalPatterns, rank = "Kingdom", abund_values = "relabundance")
+plotAbundance(GlobalPatterns, rank = "Kingdom", assay_name = "relabundance")
 ```
 
 With subsetting to selected features the plot can be fine tuned.
@@ -79,7 +79,7 @@ prev_phylum <- getPrevalentTaxa(GlobalPatterns, rank = "Phylum",
 ```{r}
 plotAbundance(GlobalPatterns[rowData(GlobalPatterns)$Phylum %in% prev_phylum],
               rank = "Phylum",
-              abund_values = "relabundance")
+              assay_name = "relabundance")
 ```
 
 The `features` argument is reused for plotting data along the different samples.
@@ -92,7 +92,7 @@ library(patchwork)
 plots <- plotAbundance(GlobalPatterns[rowData(GlobalPatterns)$Phylum %in% prev_phylum],
                        features = "SampleType",
                        rank = "Phylum",
-                       abund_values = "relabundance")
+                       assay_name = "relabundance")
 plots$abundance / plots$SampleType +
      plot_layout(heights = c(9, 1))
 ```
@@ -157,7 +157,7 @@ rowData(altExp(GlobalPatterns,"Genus"))$detected <-
 top_taxa <- getTopTaxa(altExp(GlobalPatterns,"Genus"),
                        method="mean",
                        top=100L,
-                       abund_values="counts")
+                       assay_name="counts")
 ```
 
 Colour, size and shape of tree tips and nodes can be decorated based on data
@@ -278,14 +278,14 @@ plotSeries(silverman,
 ```
 If replicated data is present, data is automatically used for calculation of the
 `mean` and `sd` and plotted as a range. Data from different assays can be used
-for plotting via the `abund_values`.
+for plotting via the `assay_name`.
 
 ```{r eval=FALSE}
 plotSeries(silverman[taxa,],
            x = "DAY_ORDER",
            colour_by = "Family",
            linetype_by = "Phylum",
-           abund_values = "relabundance")
+           assay_name = "relabundance")
 ```
 
 Additional variables can be used to modify line type aesthetics.
@@ -296,7 +296,7 @@ plotSeries(silverman,
            y = getTopTaxa(silverman, 5),
            colour_by = "Family",
            linetype_by = "Phylum",
-           abund_values = "counts")
+           assay_name = "counts")
 ```
 
 # Plotting factor data
@@ -362,88 +362,74 @@ Retrieving information about all available trajectories:
 
 ```{r}
 colData(tse)$time <- as.factor(colData(tse)$time)
-# trajectories info
-traj_info <- table(colData(tse)$subject,colData(tse)$time)
-# has at least two points
-traj_info <- traj_info[rowSums(traj_info)!=1,]
-table(rowSums(traj_info)) %>% as.data.frame() %>%
-    `colnames<-`(c("Trajectories Lengths", "Counts"))
+table(table(tse$subject)) %>% as.data.frame() %>%
+    rename(Timepoints=Var1, Subjects=Freq)
 ```
 
 Lets look at all present trajectories in the data:
 
 ```{r}
-# keeping only data that has one-to-one link from one point to another
-df <- traj_info %>% as.data.frame() %>%
-    `colnames<-`(c("subject", "time", "value")) %>% 
-    filter(value ==1) %>% arrange(subject, time) 
-# retrieving corresponding ordination coordinate values
-df <- cbind(df, 
-      reducedDim(
-          tse[,(colData(tse)$subject %in% df$subject &
-                    colData(tse)$time %in% df$time)], "PCoA_BC") %>%
-          `colnames<-`(c("PC1","PC2")) %>% as_tibble(rownames = "sample_id") %>% 
-          mutate(subject=colData(tse)[sample_id,"subject"]) %>%
-          arrange(subject)) %>% select(-last_col())
-# retrieving the corresponding start and end of each trajectory 
-df_start_end <- rbind(
-    df %>% group_by(subject) %>% slice(which.min(time)) %>% ungroup() %>%
-        mutate(tp=rep("start",nrow(.))),
-    df %>% group_by(subject) %>% slice(which.max(time)) %>% ungroup() %>%
-        mutate(tp=rep("end",nrow(.)))
-)
 # plot
-p1 + 
-    geom_path(aes(x=PC1, y=PC2, color=subject),
-              data = df )+ 
-    geom_point(aes(x=PC1,y=PC2, shape=tp),
-               data = df_start_end ,
-               size=2)+
-    scale_shape_manual(name="",values = c("start"=8, "end"=5))+
+# List subjects with two time points
+selected.subjects <- names(which(table(tse$subject)>=2))
+
+# plot
+p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
+         labs(title="PCoA - Bray-Curtis")+
+    theme(plot.title = element_text(hjust = 0.5))
+
+# plot
+df <- reducedDim(tse)
+colnames(df) <- paste0("PC", 1:2)
+df <- cbind(df, colData(tse)) %>% as.data.frame()
+
+p1 <- p1 + geom_path(aes(x=PC1, y=PC2, group=subject),
+              arrow=arrow(length = unit(0.1, "inches")),
+              data = subset(df, subject %in% selected.subjects))+ 
     labs(title = "All present trajectories")
+
+print(p1)
 ```
 
 Filtering by trajectory length and displaying top 10%:
 
 ```{r}
-# calculating trajectory lengths and merge
+# calculating trajectory lengths as sum of euclidean distances (based on the 
+# ordination coordinates) of each successive time points in each series.
 df <- merge(df,
                df %>% group_by(subject) %>% group_modify(~{
+                   # distance matrix between points based on PC1 and PC2
                    mat <- as.matrix(dist(.x[,c("PC1", "PC2")]));
+                   # summing up only the distance between successive points
                    data.frame(change=sum(mat[row(mat) == col(mat) + 1]))
-               }))
+               }),
+            by.y="subject") %>% arrange(time)
 # plot
-p1 + 
+p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
+         labs(title="PCoA - Bray-Curtis")+
+    theme(plot.title = element_text(hjust = 0.5)) +
     geom_path(aes(x=PC1, y=PC2, color=change, group=subject),
-              data = df %>% top_frac(0.1, change))+
-    geom_point(aes(x=PC1,y=PC2, shape=tp),
-               data = df_start_end %>% 
-                   filter(subject %in%
-                              (df %>% top_frac(0.1, change) %>%
-                                   select(subject) %>% .[[1]] %>% unique())), 
-               size=2)+
-    scale_shape_manual(name="",values = c("start"=8, "end"=5))+
+              data = subset(df, subject %in% selected.subjects) %>%
+                  top_frac(0.1, change),
+              arrow=arrow(length = unit(0.1, "inches")))+
     labs(title = "Top 10% longest trajectories")+
     scale_color_gradient2(low="white", high="red")
+print(p1)
 ```
 
-Filtering by trajectory length and displaying top 10% along with BMI grouping:
+Filtering by trajectory length and displaying top 10% along with nationality:
 
 ```{r}
-# adding BMI grouping info
-df$bmi_group <- colData(tse)[df$sample_id, "bmi_group"]
 # plot
-p1 + 
-    geom_path(aes(x=PC1, y=PC2, color=bmi_group, group=subject),
-              data = df %>% top_frac(0.1, change))+
-    geom_point(aes(x=PC1,y=PC2, shape=tp),
-               data = df_start_end %>% 
-                   filter(subject %in%
-                              (df %>% top_frac(0.1, change) %>%
-                                   select(subject) %>% .[[1]] %>% unique())), 
-               size=2)+
-    scale_shape_manual(name="",values = c("start"=8, "end"=5))+
-    labs(title = "Top 10% longest trajectories and BMI grouping")
+p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
+         labs(title="PCoA - Bray-Curtis")+
+    theme(plot.title = element_text(hjust = 0.5)) +
+    geom_path(aes(x=PC1, y=PC2, color=nationality, group=subject),
+              data = subset(df, subject %in% selected.subjects) %>%
+                  top_frac(0.1, change),
+              arrow=arrow(length = unit(0.1, "inches")))+
+    labs(title = "Top 10% longest trajectories and nationality")
+print(p1)
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -478,8 +478,8 @@ df <- cbind(df,
 #           `colnames<-`(c("PC1","PC2")))
 
 p1 + 
-    geom_line(aes(x=PC1, y=PC2, color=subject),
-              data = df %>% filter(subject %in% ids_2tp)) # 
+    geom_path(aes(x=PC1, y=PC2, color=subject),
+              data = df %>% filter(subject %in% ids_max_tp)) # 
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -366,12 +366,12 @@ table(table(tse$subject)) %>% as.data.frame() %>%
     rename(Timepoints=Var1, Subjects=Freq)
 ```
 
-Lets look at all present trajectories in the data:
+Lets look at all trajectories having two time points in the data:
 
 ```{r}
 # plot
 # List subjects with two time points
-selected.subjects <- names(which(table(tse$subject)>=2))
+selected.subjects <- names(which(table(tse$subject)==2))
 
 # plot
 p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
@@ -386,7 +386,7 @@ df <- cbind(df, colData(tse)) %>% as.data.frame()
 p1 <- p1 + geom_path(aes(x=PC1, y=PC2, group=subject),
               arrow=arrow(length = unit(0.1, "inches")),
               data = subset(df, subject %in% selected.subjects))+ 
-    labs(title = "All present trajectories")
+    labs(title = "All trajectories with two time points")
 
 print(p1)
 ```
@@ -412,7 +412,7 @@ p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
               data = subset(df, subject %in% selected.subjects) %>%
                   top_frac(0.1, change),
               arrow=arrow(length = unit(0.1, "inches")))+
-    labs(title = "Top 10% longest trajectories")+
+    labs(title = "Top 10% trajectories having highest change from time point one to two")+
     scale_color_gradient2(low="white", high="red")
 print(p1)
 ```
@@ -425,10 +425,25 @@ p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
          labs(title="PCoA - Bray-Curtis")+
     theme(plot.title = element_text(hjust = 0.5)) +
     geom_path(aes(x=PC1, y=PC2, color=nationality, group=subject),
-              data = subset(df, subject %in% selected.subjects) %>%
-                  top_frac(0.1, change),
+              data = subset(df, subject %in% selected.subjects) ,
               arrow=arrow(length = unit(0.1, "inches")))+
-    labs(title = "Top 10% longest trajectories and nationality")
+    labs(title = "Trajectories with two time points and nationality")
+print(p1)
+```
+
+Plotting an example of the longest trajectory within the data:
+
+```{r}
+# Get first subject to have maximum time points
+selected.subjects <- names(which.max(table(tse$subject)))
+# plot
+p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
+         labs(title="PCoA - Bray-Curtis")+
+    theme(plot.title = element_text(hjust = 0.5)) +
+    geom_path(aes(x=PC1, y=PC2, group=subject),
+              data = df %>% filter(change==max(change)) ,
+              arrow=arrow(length = unit(0.1, "inches")))+
+    labs(title = "Longest trajectory")
 print(p1)
 ```
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -55,7 +55,7 @@ behaves as `plotExpression`.
 
 ```{r}
 plotAbundance(GlobalPatterns, rank = NULL, 
-              features = "549322", assay_name = "counts")
+              features = "549322", abund_values = "counts")
 ```
 
 However, if the `rank` is set not `NULL` a bar plot is returned. At the same
@@ -66,7 +66,7 @@ GlobalPatterns <- transformCounts(GlobalPatterns, method = "relabundance")
 ```
 
 ```{r}
-plotAbundance(GlobalPatterns, rank = "Kingdom", assay_name = "relabundance")
+plotAbundance(GlobalPatterns, rank = "Kingdom", abund_values = "relabundance")
 ```
 
 With subsetting to selected features the plot can be fine tuned.
@@ -79,7 +79,7 @@ prev_phylum <- getPrevalentTaxa(GlobalPatterns, rank = "Phylum",
 ```{r}
 plotAbundance(GlobalPatterns[rowData(GlobalPatterns)$Phylum %in% prev_phylum],
               rank = "Phylum",
-              assay_name = "relabundance")
+              abund_values = "relabundance")
 ```
 
 The `features` argument is reused for plotting data along the different samples.
@@ -92,7 +92,7 @@ library(patchwork)
 plots <- plotAbundance(GlobalPatterns[rowData(GlobalPatterns)$Phylum %in% prev_phylum],
                        features = "SampleType",
                        rank = "Phylum",
-                       assay_name = "relabundance")
+                       abund_values = "relabundance")
 plots$abundance / plots$SampleType +
      plot_layout(heights = c(9, 1))
 ```
@@ -157,7 +157,7 @@ rowData(altExp(GlobalPatterns,"Genus"))$detected <-
 top_taxa <- getTopTaxa(altExp(GlobalPatterns,"Genus"),
                        method="mean",
                        top=100L,
-                       assay_name="counts")
+                       abund_values="counts")
 ```
 
 Colour, size and shape of tree tips and nodes can be decorated based on data
@@ -278,14 +278,14 @@ plotSeries(silverman,
 ```
 If replicated data is present, data is automatically used for calculation of the
 `mean` and `sd` and plotted as a range. Data from different assays can be used
-for plotting via the `assay_name`.
+for plotting via the `abund_values`.
 
 ```{r eval=FALSE}
 plotSeries(silverman[taxa,],
            x = "DAY_ORDER",
            colour_by = "Family",
            linetype_by = "Phylum",
-           assay_name = "relabundance")
+           abund_values = "relabundance")
 ```
 
 Additional variables can be used to modify line type aesthetics.
@@ -296,7 +296,7 @@ plotSeries(silverman,
            y = getTopTaxa(silverman, 5),
            colour_by = "Family",
            linetype_by = "Phylum",
-           assay_name = "counts")
+           abund_values = "counts")
 ```
 
 # Plotting factor data

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -334,7 +334,7 @@ if (!requireNamespace("devtools", quietly = TRUE))
 devtools::install_github("microbiome/miaTime")
 ```
 
-Principal Coordinate Analysis using Bray-Curtis dissimilarity on the
+Principal Coordinates Analysis using Bray-Curtis dissimilarity on the
 `hitchip1006` dataset:
 
 ```{r}
@@ -350,18 +350,21 @@ tse <- runMDS(tse, FUN = vegan::vegdist, method = "bray",
 e <- attr(reducedDim(tse, "PCoA_BC"), "eig")
 rel_eig <- e/sum(e[e>0])
 # plot
-p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
-    labs(x = paste("PCoA 1 (", round(100 * rel_eig[[1]],1), "%", ")", sep = ""),
+p <- plotReducedDim(tse, dimred = "PCoA_BC")
+
+p + labs(x = paste("PCoA 1 (", round(100 * rel_eig[[1]],1), "%", ")", sep = ""),
          y = paste("PCoA 2 (", round(100 * rel_eig[[2]],1), "%", ")", sep = ""),
          title="PCoA - Bray-Curtis")+
     theme(plot.title = element_text(hjust = 0.5))
-p1
 ```
 
 Retrieving information about all available trajectories:
 
 ```{r}
-colData(tse)$time <- as.factor(colData(tse)$time)
+# List subjects with two time points
+selected.subjects <- names(which(table(tse$subject)==2))
+
+# Subjects counts per number of time points available in the data
 table(table(tse$subject)) %>% as.data.frame() %>%
     rename(Timepoints=Var1, Subjects=Freq)
 ```
@@ -369,82 +372,51 @@ table(table(tse$subject)) %>% as.data.frame() %>%
 Lets look at all trajectories having two time points in the data:
 
 ```{r}
+# adding metadata for the plot
+p$data <- cbind(p$data, colData(tse))
 # plot
-# List subjects with two time points
-selected.subjects <- names(which(table(tse$subject)==2))
-
-# plot
-p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
-         labs(title="PCoA - Bray-Curtis")+
-    theme(plot.title = element_text(hjust = 0.5))
-
-# plot
-df <- reducedDim(tse)
-colnames(df) <- paste0("PC", 1:2)
-df <- cbind(df, colData(tse)) %>% as.data.frame()
-
-p1 <- p1 + geom_path(aes(x=PC1, y=PC2, group=subject),
+p + geom_path(aes(x=X, y=Y, group=subject), 
               arrow=arrow(length = unit(0.1, "inches")),
-              data = subset(df, subject %in% selected.subjects))+ 
-    labs(title = "All trajectories with two time points")
-
-print(p1)
+              data = subset(p$data, subject %in% selected.subjects))+
+    labs(title = "All trajectories with two time points")+
+    theme(plot.title = element_text(hjust = 0.5))
 ```
 
-Filtering by trajectory length and displaying top 10%:
+Filtering the two time point trajectories by divergence and displaying top 10%:
 
 ```{r}
-# calculating trajectory lengths as sum of euclidean distances (based on the 
-# ordination coordinates) of each successive time points in each series.
-df <- merge(df,
-               df %>% group_by(subject) %>% group_modify(~{
-                   # distance matrix between points based on PC1 and PC2
-                   mat <- as.matrix(dist(.x[,c("PC1", "PC2")]));
-                   # summing up only the distance between successive points
-                   data.frame(change=sum(mat[row(mat) == col(mat) + 1]))
-               }),
-            by.y="subject") %>% arrange(time)
+library(miaTime)
+# calculating step wise divergence based on the microbial profiles
+tse <- getStepwiseDivergence(tse, group = "subject", time_field = "time")
+# adding metadata for the plot
+p$data <- cbind(p$data, colData(tse)[,"time_divergence", drop=FALSE])
+# retrieving the top 10% divergent subjects having two time points
+top.selected.subjects <- p$data %>% filter(subject %in% selected.subjects) %>%
+    top_frac(0.1, time_divergence) %>% select(subject) %>% .[[1]]
 # plot
-p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
-         labs(title="PCoA - Bray-Curtis")+
-    theme(plot.title = element_text(hjust = 0.5)) +
-    geom_path(aes(x=PC1, y=PC2, color=change, group=subject),
-              data = subset(df, subject %in% selected.subjects) %>%
-                  top_frac(0.1, change),
-              arrow=arrow(length = unit(0.1, "inches")))+
-    labs(title = "Top 10% trajectories having highest change from time point one to two")+
-    scale_color_gradient2(low="white", high="red")
-print(p1)
+p + geom_path(aes(x=X, y=Y,
+                  color=time_divergence, group=subject),
+              data = subset(p$data, subject %in% top.selected.subjects) %>% 
+                  arrange(desc(time)), 
+              arrow=arrow(length = unit(0.1, "inches"), ends = "first"))+
+    labs(title = "Top 10%  divergent trajectories from time point one to two")+
+    scale_color_gradient2(low="white", high="red")+
+    theme(plot.title = element_text(hjust = 0.5))
 ```
 
-Filtering by trajectory length and displaying top 10% along with nationality:
-
-```{r}
-# plot
-p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
-         labs(title="PCoA - Bray-Curtis")+
-    theme(plot.title = element_text(hjust = 0.5)) +
-    geom_path(aes(x=PC1, y=PC2, color=nationality, group=subject),
-              data = subset(df, subject %in% selected.subjects) ,
-              arrow=arrow(length = unit(0.1, "inches")))+
-    labs(title = "Trajectories with two time points and nationality")
-print(p1)
-```
-
-Plotting an example of the longest trajectory within the data:
+Plotting an example of the trajectory with the highest total divergence:
 
 ```{r}
 # Get first subject to have maximum time points
-selected.subjects <- names(which.max(table(tse$subject)))
+selected.subject <- p$data %>% group_by(subject) %>%
+    summarise(total_divergence=sum(time_divergence, na.rm = TRUE)) %>%
+    filter(total_divergence==max(total_divergence)) %>% select(subject) %>% .[[1]]
 # plot
-p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
-         labs(title="PCoA - Bray-Curtis")+
-    theme(plot.title = element_text(hjust = 0.5)) +
-    geom_path(aes(x=PC1, y=PC2, group=subject),
-              data = df %>% filter(change==max(change)) ,
+p +  geom_path(aes(x=X, y=Y, group=subject),
+              data = subset(p$data, subject %in% selected.subject),
               arrow=arrow(length = unit(0.1, "inches")))+
-    labs(title = "Longest trajectory")
-print(p1)
+    labs(title = "Longest trajectory by divergence")+
+    theme(plot.title = element_text(hjust = 0.5))
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -350,7 +350,7 @@ p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
 p1
 ```
 
-Retrieving information about available trajectories:
+Retrieving information about all available trajectories:
 
 ```{r}
 colData(tse)$time <- as.factor(colData(tse)$time)
@@ -362,97 +362,14 @@ table(rowSums(traj_info)) %>% as.data.frame() %>%
     `colnames<-`(c("Trajectories Lengths", "Counts"))
 ```
 
-Lets look at trajectories with two time points:
+Lets look at all present trajectories in th data:
 
 ```{r}
-# subject with 2 points trajectory
-ids_2tp <- which(rowSums(traj_info)==2) %>% names()
-
-df <- data.frame(
-    reducedDim(tse[,colData(tse)$subject %in% ids_2tp],"PCoA_BC") %>%
-        `colnames<-`(c("PCoA1","PCoA2")),
-    colData(tse[,colData(tse)$subject %in% ids_2tp])[,c("time","subject")]) %>%
-    arrange(subject) %>% mutate(time_mod=rep(c("tp_1","tp_2"), nrow(.)/2)) %>% 
-    tidyr::pivot_wider(id_cols = subject, names_from = time_mod,
-                       values_from = c(PCoA1,PCoA2)) %>% 
-    `colnames<-`(c("subject","x_start", "x_end", "y_start", "y_end")) %>% 
-    mutate(change=sqrt((.[[3]]-.[[2]])^2+(.[[5]]-.[[4]])^2))
-
-p1 + 
-    geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
-                     color=change), data = df, 
-                 arrow = arrow(length = unit(0.1,"cm")))+
-    labs(title = "All two time point trajectories")
-```
-
-top 10 % trajectories (in terms of change) with two time points:
-
-```{r}
-p1 + 
-    geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
-                     color=change), data = df %>% top_frac(0.1, change), 
-                 arrow = arrow(length = unit(0.1,"cm")))+
-    labs(title = "top 10% trajectories from time point 1 to 2")
-```
-
-Coloring trajectories with metadata (e.g. nationality): 
-
-```{r}
-df <- df %>%
-    mutate(colData(tse) %>% as_tibble()  %>%
-    filter(subject %in% df$subject) %>% select(subject, nationality) %>%
-    distinct() %>% select(nationality))
-
-p1 + 
-    geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
-                     color=nationality), data = df, 
-                 arrow = arrow(length = unit(0.1,"cm")))+
-    labs(title = "Trajectories coloured with nationality ")
-```
-
-Trajectories with multiple points (e.g. 5 poins which was maximum):
-
-```{r}
-# subject with maximum points in a trajectory
-max_tp <- max(rowSums(traj_info))
-ids_max_tp <- which(rowSums(traj_info)==max_tp) %>% names()
-
-DF <- data.frame(
-    reducedDim(tse[,colData(tse)$subject %in% ids_max_tp],"PCoA_BC") %>%
-        `colnames<-`(c("PCoA1","PCoA2")),
-    colData(tse[,colData(tse)$subject %in% ids_max_tp])[,c("time","subject")]) %>%
-    arrange(subject) %>% mutate(time_mod=rep(paste0("tp_", seq(max_tp)), nrow(.)/max_tp)) %>% 
-    tidyr::pivot_wider(id_cols = subject, names_from = time_mod,
-                       values_from = c(PCoA1,PCoA2))
-df <- DF %>% select(c(subject,PCoA1_tp_1, PCoA2_tp_1, PCoA1_tp_2, PCoA2_tp_2)) %>% 
-    `colnames<-`(c("subject","x_start","y_start", "x_end", "y_end"))
-for (i in 2:(max_tp-1)) {
-    df <- rbind(df,
-                DF %>% select(c("subject",
-                                paste0(c("PCoA1_tp_","PCoA2_tp_"),i),
-                                paste0(c("PCoA1_tp_","PCoA2_tp_"),i+1))) %>% 
-    `colnames<-`(c("subject","x_start","y_start", "x_end", "y_end")))
-}
-
-df_start_end <- rbind(
-    DF[,grep("tp_1", colnames(DF))] %>% `colnames<-`(c("PCoA1","PCoA2")) %>%
-        mutate(tp=rep("start", nrow(.))),
-    DF[,grep(paste0("tp_",max_tp), colnames(DF))] %>%
-        `colnames<-`(c("PCoA1","PCoA2")) %>% mutate(tp=rep("end", nrow(.))))
-
-p1 + 
-    geom_segment(aes(x=x_start, y=y_start, xend=x_end, yend=y_end,
-                     color=subject), data = df)+
-    geom_point(aes(x=PCoA1,y=PCoA2, shape=tp),data = df_start_end, size=2)+
-    scale_shape_manual(name="",values = c("start"=8, "end"=5))+
-    labs(title = "Multiple points trajectories")
-```
-
-
-```{r}
-df <- traj_info %>% as.data.frame() %>% `colnames<-`(c("subject", "time", "value")) %>%
+# keeping only data that has one-to-one link from one point to another
+df <- traj_info %>% as.data.frame() %>%
+    `colnames<-`(c("subject", "time", "value")) %>% 
     filter(value ==1) %>% arrange(subject, time) 
-
+# retrieving corresponding ordination coordinate values
 df <- cbind(df, 
       reducedDim(
           tse[,(colData(tse)$subject %in% df$subject &
@@ -460,19 +377,45 @@ df <- cbind(df,
           `colnames<-`(c("PC1","PC2")) %>% as_tibble(rownames = "sample_id") %>% 
           mutate(subject=colData(tse)[sample_id,"subject"]) %>%
           arrange(subject)) %>% select(-last_col())
-
+# retrieving the corresponding start and end of each trajectory 
 df_start_end <- rbind(
-    df %>% group_by(subject) %>% slice(which.min(time)) %>% ungroup() %>% mutate(tp=rep("start",nrow(.))),
-    df %>% group_by(subject) %>% slice(which.max(time)) %>% ungroup() %>% mutate(tp=rep("end",nrow(.)))
+    df %>% group_by(subject) %>% slice(which.min(time)) %>% ungroup() %>%
+        mutate(tp=rep("start",nrow(.))),
+    df %>% group_by(subject) %>% slice(which.max(time)) %>% ungroup() %>%
+        mutate(tp=rep("end",nrow(.)))
 )
-
+# plot
 p1 + 
     geom_path(aes(x=PC1, y=PC2, color=subject),
               data = df )+ # %>% filter(subject %in% ids_max_tp)
     geom_point(aes(x=PC1,y=PC2, shape=tp),
                data = df_start_end , # %>% filter(subject %in% ids_max_tp)
                size=2)+
-    scale_shape_manual(name="",values = c("start"=8, "end"=5))
+    scale_shape_manual(name="",values = c("start"=8, "end"=5))+
+    labs(title = "All present trajectories")
+```
+
+Filtering by trajectory length:
+
+```{r}
+# calculating trajectory lengths and merge
+df <- merge(df,
+               df %>% group_by(subject) %>% group_modify(~{
+                   mat <- as.matrix(dist(.x[,c("PC1", "PC2")]));
+                   data.frame(change=sum(mat[row(mat) == col(mat) + 1]))
+               }))
+# plot
+p1 + 
+    geom_path(aes(x=PC1, y=PC2, color=subject),
+              data = df %>% top_frac(0.1, change))+
+    geom_point(aes(x=PC1,y=PC2, shape=tp),
+               data = df_start_end %>% 
+                   filter(subject %in%
+                              (df %>% top_frac(0.1, change) %>%
+                                   select(subject) %>% .[[1]] %>% unique())), 
+               size=2)+
+    scale_shape_manual(name="",values = c("start"=8, "end"=5))+
+    labs(title = "Top 10% longest trajectories")
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -452,12 +452,7 @@ p1 +
 ```{r}
 df <- traj_info %>% as.data.frame() %>% `colnames<-`(c("subject", "time", "value")) %>%
     filter(value ==1) %>% arrange(subject, time) 
-# %>% 
-#     mutate(sample_id = apply(., 1, function(row) {
-#         colData(tse[,colData(tse)$subject == row[1] & colData(tse)$time == row[2]])$sample
-#         }))
-    
-#df$subject <- as.factor(df$subject)
+
 df <- cbind(df, 
       reducedDim(
           tse[,(colData(tse)$subject %in% df$subject &
@@ -465,21 +460,19 @@ df <- cbind(df,
           `colnames<-`(c("PC1","PC2")) %>% as_tibble(rownames = "sample_id") %>% 
           mutate(subject=colData(tse)[sample_id,"subject"]) %>%
           arrange(subject)) %>% select(-last_col())
-# df_start_end <- df %>% group_by(subject) %>% summarise(start=min(time), end=max(time)) %>%
-#     tidyr::pivot_longer(cols = c(start, end), names_to = "side", values_to = "time") %>% 
-#     mutate(sample_id = apply(., 1, function(row) {
-#         colData(tse[,colData(tse)$subject == row[1] & colData(tse)$time == row[3]])$sample
-#         }))
-# df_start_end <- cbind(
-#     df_start_end,
-#     reducedDim(
-#           tse[,(colData(tse)$subject %in% df_start_end$subject &
-#                     colData(tse)$time %in% df_start_end$time)], "PCoA_BC") %>%
-#           `colnames<-`(c("PC1","PC2")))
+
+df_start_end <- rbind(
+    df %>% group_by(subject) %>% slice(which.min(time)) %>% ungroup() %>% mutate(tp=rep("start",nrow(.))),
+    df %>% group_by(subject) %>% slice(which.max(time)) %>% ungroup() %>% mutate(tp=rep("end",nrow(.)))
+)
 
 p1 + 
     geom_path(aes(x=PC1, y=PC2, color=subject),
-              data = df %>% filter(subject %in% ids_max_tp)) # 
+              data = df )+ # %>% filter(subject %in% ids_max_tp)
+    geom_point(aes(x=PC1,y=PC2, shape=tp),
+               data = df_start_end , # %>% filter(subject %in% ids_max_tp)
+               size=2)+
+    scale_shape_manual(name="",values = c("start"=8, "end"=5))
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -450,18 +450,21 @@ p1 +
 
 
 ```{r}
-df <- traj_info %>% reshape2::melt() %>% `colnames<-`(c("subject", "time", "value")) %>%
-    filter(value>0) %>% arrange(subject, time) %>% 
-    mutate(sample_id = apply(., 1, function(row) {
-        colData(tse[,colData(tse)$subject == row[1] & colData(tse)$time == row[2]])$sample
-        }))
+df <- traj_info %>% as.data.frame() %>% `colnames<-`(c("subject", "time", "value")) %>%
+    filter(value ==1) %>% arrange(subject, time) 
+# %>% 
+#     mutate(sample_id = apply(., 1, function(row) {
+#         colData(tse[,colData(tse)$subject == row[1] & colData(tse)$time == row[2]])$sample
+#         }))
     
-df$subject <- as.factor(df$subject)
+#df$subject <- as.factor(df$subject)
 df <- cbind(df, 
       reducedDim(
           tse[,(colData(tse)$subject %in% df$subject &
                     colData(tse)$time %in% df$time)], "PCoA_BC") %>%
-          `colnames<-`(c("PC1","PC2")))
+          `colnames<-`(c("PC1","PC2")) %>% as_tibble(rownames = "sample_id") %>% 
+          mutate(subject=colData(tse)[sample_id,"subject"]) %>%
+          arrange(subject)) %>% select(-last_col())
 # df_start_end <- df %>% group_by(subject) %>% summarise(start=min(time), end=max(time)) %>%
 #     tidyr::pivot_longer(cols = c(start, end), names_to = "side", values_to = "time") %>% 
 #     mutate(sample_id = apply(., 1, function(row) {
@@ -475,7 +478,8 @@ df <- cbind(df,
 #           `colnames<-`(c("PC1","PC2")))
 
 p1 + 
-    geom_line(aes(x=PC1, y=PC2, color=subject), data = df)
+    geom_line(aes(x=PC1, y=PC2, color=subject),
+              data = df %>% filter(subject %in% ids_2tp)) # 
 ```
 
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -328,6 +328,12 @@ plotDMNFit(dmn_se, type = "laplace")
 
 # Serial data ordination and trajectories
 
+```{r, error=FALSE, warning=FALSE, results='hide'}
+if (!requireNamespace("devtools", quietly = TRUE))
+    install.packages("devtools")
+devtools::install_github("microbiome/miaTime")
+```
+
 Principal Coordinate Analysis using Bray-Curtis dissimilarity on the
 `hitchip1006` dataset:
 

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -326,6 +326,68 @@ names(metadata(dmn_se))
 plotDMNFit(dmn_se, type = "laplace")
 ```
 
+# Ordination of serial data and trajectories
+
+```{r}
+library(dplyr)
+data(temporalMicrobiome20, package = "miaTime")
+## Pre-processing data
+# removing NAs
+tse <- temporalMicrobiome20[,colData(temporalMicrobiome20)$Day_Number!="NA"]
+# making Day_Number as factor
+colData(tse)$Day_Number <- colData(tse)$Day_Number %>% as.integer() %>%
+    as.factor()
+## transforming data
+# imputing missing values with 0
+assay(tse,"counts")[is.na(assay(tse,"counts"))] <- 0 # is ok?
+# relative abundance transform
+tse <- transformCounts(tse, abund_values = "counts", method = "relabundance",
+                       pseudocount = 1)
+## Ordination with PCoA with Bray-Curtis dissimilarity
+tse <- runMDS(tse, FUN = vegan::vegdist, method = "bray",
+                  name = "PCoA_BC", exprs_values = "relabundance",
+              na.rm = TRUE)
+# Calculating Explained variance
+e <- attr(reducedDim(tse, "PCoA_BC"), "eig")
+rel_eig <- e/sum(e[e>0])
+# plot
+p1 <- plotReducedDim(tse, dimred = "PCoA_BC") +
+    labs(x = paste("PCoA 1 (", round(100 * rel_eig[[1]],1), "%", ")", sep = ""),
+         y = paste("PCoA 2 (", round(100 * rel_eig[[2]],1), "%", ")", sep = ""),
+         title="PCoA - Bray-Curtis")+
+    theme(plot.title = element_text(hjust = 0.5))
+p1
+```
+
+With two points; day 1 and day 30:
+
+```{r}
+df <- data.frame(reducedDim(tse) %>% `colnames<-`(c("PCoA1","PCoA2")),
+                 colData(tse)[,c("Day_Number","ID_Number")]) %>%
+    filter(Day_Number %in% c(1,30)) %>%
+    tidyr::pivot_wider(id_cols = ID_Number, names_from = Day_Number,
+                       values_from = c(PCoA1,PCoA2)) %>% 
+    mutate(change=sqrt((PCoA1_30-PCoA1_1)^2+(PCoA2_30-PCoA2_1)^2))
+
+p1 + 
+    geom_segment(aes(x=PCoA1_1, y=PCoA2_1, xend=PCoA1_30, yend=PCoA2_30,
+                     color=change), data = df, 
+                 arrow = arrow(length = unit(0.1,"cm")))
+```
+
+Examples of 30 days trajectories:
+
+```{r}
+# making info of samples corresponding to IDs having measurements up till 30 days
+IDs_keep <- sapply(colData(tse)$ID_Number %>% unique, function(id_n) {
+    if(seq(30) %in%
+       colData(tse)[colData(tse)$ID_Number==id_n, "Day_Number"] %>%
+       all) id_n
+})
+colData(tse)$has_30d <- 
+```
+
+
 More examples and materials are available at Orchestrating Microbiome Analysis [@OMA].
 
 # Session info


### PR DESCRIPTION
Hi,

This is related to #64 .

- Available trajectories information is retrieved as a contingency table (adjacency matrix like).
- Only 1-to-1 points mappings are kept (e.g. same subject same time replicate measurements are discarded).
- Plotting all trajectories with start and end of each.
- Filtering trajectories by length (computed as sum of euclidean distances between each successive points in each series).
- Including example from colData.