### PR TITLE
Fix vignette error

### DIFF
--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -331,7 +331,7 @@ plotDMNFit(dmn_se, type = "laplace")
 
 ```{r, error=FALSE, warning=FALSE, results='hide'}
 if(!requireNamespace("devtools", quietly = TRUE)){
-    install.packages("devtools")
+    Biocmanager::install("devtools")
 }
 if(!requireNamespace("miaTime", quietly = TRUE)){
     devtools::install_github("microbiome/miaTime")

--- a/vignettes/miaViz.Rmd
+++ b/vignettes/miaViz.Rmd
@@ -331,7 +331,7 @@ plotDMNFit(dmn_se, type = "laplace")
 
 ```{r, error=FALSE, warning=FALSE, results='hide'}
 if(!requireNamespace("devtools", quietly = TRUE)){
-    Biocmanager::install("devtools")
+    BiocManager::install("devtools")
 }
 if(!requireNamespace("miaTime", quietly = TRUE)){
     devtools::install_github("microbiome/miaTime")


### PR DESCRIPTION
http://bioconductor.org/checkResults/devel/bioc-LATEST/miaViz/nebbiolo1-checksrc.html

Error when vignette is tested. 

Quitting from lines 333-339 (miaViz.Rmd) 
Error: processing vignette 'miaViz.Rmd' failed with diagnostics:
trying to use CRAN without setting a mirror

BiocManager::install uses pre-configured CRAN mirrors --> should fix the problem