### PR TITLE
replace addTaxonomyTree with addHierarchyTree

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: miaViz
 Title: Microbiome Analysis Plotting and Visualization
-Version: 1.11.0
+Version: 1.11.1
 Authors@R: 
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",
@@ -62,5 +62,5 @@ Suggests:
     microbiomeDataSets,
     bluster
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 VignetteBuilder: knitr

--- a/NEWS
+++ b/NEWS
@@ -23,3 +23,4 @@ Changes in version 1.9.x
 + Added plotCCA and plotRDA functions
 
 Changes in version 1.11.x
++ replace addTaxonomyTree with addHierarchyTree after renaming in mia package

--- a/R/plotTree.R
+++ b/R/plotTree.R
@@ -162,7 +162,7 @@
 #'               y
 #'           })
 #' x <- unsplitByRanks(GlobalPatterns)
-#' x <- addTaxonomyTree(x)
+#' x <- addHierarchyTree(x)
 #' 
 #' highlights <- c("Phylum:Firmicutes","Phylum:Bacteroidetes",
 #'                 "Family:Pseudomonadaceae","Order:Bifidobacteriales")

--- a/man/miaViz-package.Rd
+++ b/man/miaViz-package.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/miaViz.R
 \docType{package}
 \name{miaViz-package}
+\alias{miaViz}
 \alias{miaViz-package}
 \title{miaViz - Microbiome Analysis Plotting and Visualization}
 \description{
@@ -11,4 +12,20 @@ class.
 }
 \seealso{
 \link[mia:mia-package]{mia} class
+}
+\author{
+\strong{Maintainer}: Tuomas Borman \email{tuomas.v.borman@utu.fi} (\href{https://orcid.org/0000-0002-8563-8884}{ORCID})
+
+Authors:
+\itemize{
+  \item Felix G.M. Ernst \email{felix.gm.ernst@outlook.com} (\href{https://orcid.org/0000-0001-5064-0928}{ORCID})
+  \item Leo Lahti \email{leo.lahti@iki.fi} (\href{https://orcid.org/0000-0001-5537-637X}{ORCID})
+}
+
+Other contributors:
+\itemize{
+  \item Basil Courbayre [contributor]
+  \item Giulio Benedetti \email{giulio.benedetti@utu.fi} (\href{https://orcid.org/0000-0002-8732-7692}{ORCID}) [contributor]
+}
+
 }

--- a/man/plotTree.Rd
+++ b/man/plotTree.Rd
@@ -223,7 +223,7 @@ altExps(GlobalPatterns) <-
               y
           })
 x <- unsplitByRanks(GlobalPatterns)
-x <- addTaxonomyTree(x)
+x <- addHierarchyTree(x)
 
 highlights <- c("Phylum:Firmicutes","Phylum:Bacteroidetes",
                 "Family:Pseudomonadaceae","Order:Bifidobacteriales")


### PR DESCRIPTION
After renaming `addTaxonomyTree` to `addHierarchyTree` in the mia package, this PR replace `addTaxonomyTree` with `addHierarchyTree` in the miaViz package.