### PR TITLE
plotLoadings, absolute scale

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: miaViz
 Title: Microbiome Analysis Plotting and Visualization
-Version: 1.13.11
+Version: 1.13.12
 Authors@R: 
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/R/plotLoadings.R
+++ b/R/plotLoadings.R
@@ -330,7 +330,8 @@ setMethod("plotLoadings", signature = c(x = "matrix"),
             geom_text(aes(
                 x = max(Value_abs) + max(Value_abs)*0.1,
                 y = reorder_within(Feature, Value_abs, PC),
-                label = Sign
+                label = Sign,
+                fontface = "bold"
                 )) +
             scale_y_reordered() +
             facet_wrap(~ PC, scales = "free") +

--- a/man/plotLoadings.Rd
+++ b/man/plotLoadings.Rd
@@ -34,6 +34,10 @@ x.}
 \itemize{
 \item \code{n}: \code{Integer scalar}. Number of features to be plotted.
 Applicable when \code{layout="barplot"}. (Default: \code{10}))
+
+\item \code{absolute.scale}: ("barplot") \code{Logical scalar}. Specifies
+whether a barplot should be visualized in absoltue scale.
+(Default: \code{TRUE})
 }}
 
 \item{dimred}{\code{Character scalar}.  Determines the reduced dimension to


### PR DESCRIPTION
Now loadings can be visualized with barplot also in absolute scale. That is the default choice.

The reason is that original scale takes too much space since values can be negative and positive. Moreover, the effect size cannot be easily compared between positive and negative values (that is the most important info)

![image](https://github.com/user-attachments/assets/4d0e6dd4-f892-480f-ba6e-eead511be307)

In absolute scale, there the comparison is easier. +/- shows whether the value is positive or negative

![image](https://github.com/user-attachments/assets/aae57f9d-6810-4840-8123-0e88dd47688a)
