### PR TITLE
Bugfix plotRDA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: miaViz
 Title: Microbiome Analysis Plotting and Visualization
-Version: 1.15.0
+Version: 1.15.1
 Authors@R: 
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/R/plotCCA.R
+++ b/R/plotCCA.R
@@ -329,11 +329,16 @@ setMethod("plotRDA", signature = c(x = "matrix"),
     }
     
     # Get data for vectors
+    # There must be at least two constrained axis to plot vectors. If there are
+    # not, give warning.
     vector_data <- NULL
-    if( add.vectors ){
+    if( add.vectors && ncol(rda$CCA$biplot) > 1 ){
         vector_data <- rda$CCA$biplot
         vector_data <- as.data.frame(vector_data)
         vector_data[["group"]] <- rownames(vector_data)
+    } else if( add.vectors ){
+        warning("Model contains only one constrained axis. Vectors cannot ",
+            "be added.", call. = FALSE)
     }
     
     # Get variable names from sample metadata


### PR DESCRIPTION
`plotRDA`/`plotCCA` did not take into account that sometimes the model has only one constrained axis (for instance if only one explanatory variable was incorporated). Vectors cannot be added if there are not at least two constrained axes.