### PR TITLE
plotRowTree and branch.length

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: miaViz
 Title: Microbiome Analysis Plotting and Visualization
-Version: 1.15.9
+Version: 1.15.10
 Authors@R: 
     c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
              email = "tuomas.v.borman@utu.fi",

--- a/R/plotTree.R
+++ b/R/plotTree.R
@@ -1120,9 +1120,22 @@ NODE_VARIABLES <- c("node_colour_by", "node_shape_by", "node_size_by")
         label.font.size = 3,
         highlight_font_size = highlight.font.size,
         highlight.font.size = 3,
+        branch.length = "branch.length",
         ...){
+    # We capture branch.length to disable other options than plotting branches
+    # as they are or with equal branch lengths. That is because user cannot
+    # control the parameter as it only specifies column from the object table.
+    # However, the table cannot include any other length scales than the
+    # original.
+    cols <- c("branch.length", "none")
+    if( !(.is_a_string(branch.length) && branch.length %in% cols) ){
+        stop("'branch.length' must be one of the following options: '",
+            paste0(cols, collapse = "', '"), "'", call. = FALSE)
+    }
     # start plotting
-    plot_out <- ggtree(object, ladderize = !order_tree, layout = layout, ...)
+    plot_out <- ggtree(
+        object, ladderize = !order_tree, layout = layout,
+        branch.length = branch.length, ...)
     # add highlights
     plot_out <- .plot_tree_plot_highlights(
         plot_out, layout, show_highlights, show_highlight_label, abbr_label,


### PR DESCRIPTION
Related to this issue: https://github.com/microbiome/miaViz/issues/175

The PR disables any other option for `branch.length` than `"branch.length"` (original branch lengths) or `"none" `(all branches have equal length).

The other options are disabled because user cannot control them. The parameter specifies a column from input data. However, the input data cannot include any other branch lengths than the actual lengths of branches retrieved from the phylogeny.