### PR TITLE
Fix plotForest tiplab matching

### DIFF
--- a/R/plotForest.R
+++ b/R/plotForest.R
@@ -150,7 +150,7 @@ NULL
 #' @export
 #' @importFrom SummarizedExperiment rowData colData
 #' @importFrom TreeSummarizedExperiment rowTree colTree rowTreeNames
-#'   colTreeNames
+#'   colTreeNames rowLinks
 #' @importFrom ggplot2 ggplot_build
 #' @importFrom patchwork wrap_plots plot_layout
 setMethod("plotForest", signature = c(x = "TreeSummarizedExperiment"),
@@ -179,9 +179,9 @@ setMethod("plotForest", signature = c(x = "TreeSummarizedExperiment"),
     }
     # Check kwargs
     kwargs <- list(...)
-    if( any(c("layout", "branch.length") %in% names(kwargs)) ){
-        stop("'layout' and 'branch.length' cannot be modified for this plot.",
-            call. = FALSE)
+    if( any(c("layout", "levels.rm", "branch.length") %in% names(kwargs)) ){
+        stop("'layout', 'levels.rm' and 'branch.length' cannot be modified ",
+            "for this plot.", call. = FALSE)
     }
     # If tree is available
     if( order_tree ){
@@ -191,14 +191,15 @@ setMethod("plotForest", signature = c(x = "TreeSummarizedExperiment"),
             tree.name = tree.name,
             layout = "rectangular",
             branch.length = "none",
-            show.label = TRUE
+            show.label = TRUE,
+            levels.rm = TRUE
         )
         # Extract tip order from tree
         tree_data <- ggplot_build(tree_plot)
         tips <- tree_data[[1]][[5]][c("y", "label")]
         tips <- tips[order(tips$y), , drop = FALSE]
         # Order rowData based on tree tips
-        tax_order <- match(tips$label, rownames(df))
+        tax_order <- match(tips$label, rowLinks(x)$nodeLab)
         df <- df[tax_order, , drop = FALSE]
     }
     # Initialise plots and widths lists
@@ -212,6 +213,7 @@ setMethod("plotForest", signature = c(x = "TreeSummarizedExperiment"),
             tree.name = tree.name,
             layout = "rectangular",
             branch.length = "none",
+            levels.rm = TRUE,
             ...
         )
         # Store tree width

--- a/tests/testthat/test-plotForest.R
+++ b/tests/testthat/test-plotForest.R
@@ -95,7 +95,7 @@ test_that("plotForest", {
     )
     expect_error(
         plotForest(tse, layout = "circular", branch.length = "none"),
-        "'layout' and 'branch.length' cannot be modified for this plot.",
+        "'layout', 'levels.rm' and 'branch.length' cannot be modified for this plot.",
         fixed = TRUE
     )
     expect_warning(


### PR DESCRIPTION
After recent miaViz updates, levels.rm arg of plotRowTree was set to TRUE by default. This caused rowname2tiplab matching issues in plotForest. It was also a problem before probably since rownames and tiplabs are not necessarily identical. Now, switched to using rowLinks nodeLab for matching, which is more robust.